### PR TITLE
Create ci-demo.yml

### DIFF
--- a/.github/workflows/ci-demo.yml
+++ b/.github/workflows/ci-demo.yml
@@ -1,0 +1,16 @@
+name: Run CI
+on: [push, pull_request]
+
+jobs:
+  normal_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run normal CI
+        run: echo "Running normal CI"
+
+  pull_request_ci:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Run PR CI
+        run: echo "Running PR only CI"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file named `ci-demo.yml`. This workflow is triggered on both `push` and `pull_request` events. It consists of two jobs: `normal_ci` and `pull_request_ci`. The `normal_ci` job runs on every trigger, while the `pull_request_ci` job only runs when the event is a pull request. Both jobs are configured to run on the latest Ubuntu environment and their steps involve echoing a message to indicate the type of CI run.