### PR TITLE
Create ci-lab.yml

### DIFF
--- a/.github/workflows/ci-lab.yml
+++ b/.github/workflows/ci-lab.yml
@@ -1,0 +1,60 @@
+########
+########
+## CI ##
+########
+########
+name: Continuous Integration
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+# Don't need to run on push to master/main
+on:
+  push:
+    branches-ignore:
+      - 'master'
+      - 'main'
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: CI
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      ########################
+      # Setup Docker build X #
+      ########################
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+
+      ##############################
+      # Build the docker container #
+      ##############################
+      - name: Build Docker container
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_VERSION=${{ github.sha }}
+          push: false


### PR DESCRIPTION
This pull request introduces a new Continuous Integration (CI) workflow file named `.github/workflows/ci-lab.yml`. The workflow is designed to run on every push event except on `master` and `main` branches. The job, named `CI`, runs on an `ubuntu-latest` environment and includes steps to checkout the code, set up Docker BuildX, and build a Docker container without pushing it. The Docker build process uses build arguments for the build date, revision, and version, which are set to environment variables and the GitHub SHA, respectively.